### PR TITLE
print stacks for unhandled rejections

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -19,3 +19,7 @@ mongoose.connect(mongoUri, { useMongoClient: true }, error => {
 });
 
 require('./server').start();
+
+process.on('unhandledRejection', (error, p) => {
+  console.error('Unhandled Rejection at: Promise', p, 'reason:', error.stack);
+});


### PR DESCRIPTION
Note that this doesn't work when app is run in production (`yarn prod`) using pm2 in cluster mode
Something related to how it deletes or ignored or doesn't pass up unhandledRejection and uncaughtExceptions

notes and bookmarks for future:

https://github.com/keymetrics/pmx/blob/master/lib/notify.js#L35
https://github.com/Unitech/pm2/issues/2226#issuecomment-272230766
https://github.com/Unitech/pm2/blob/596b29c8409246a8b5b36be9ff3904a8b5c26285/lib/ProcessContainer.js#L279-L323