### PR TITLE
✨ add sets to persona

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -24,20 +24,22 @@ const connectToMongoAndStart = ({ mongoUser, mongoPass }) => {
   });
 };
 
-vault
-  .getSecretValue(config.vaultMongoCredentialPath)
-  .then(result => {
-    connectToMongoAndStart({
-      mongoUser: result[config.mongoUsernameKey],
-      mongoPass: result[config.mongoUserpassKey],
-    });
-  })
-  .catch(error => {
-    connectToMongoAndStart({
-      mongoUser: config.mongoUser,
-      mongoPass: config.mongoPass,
-    });
+if (config.vaultMongoCredentialPath) {
+  vault
+    .getSecretValue(config.vaultMongoCredentialPath)
+    .then(result => {
+      connectToMongoAndStart({
+        mongoUser: result[config.mongoUsernameKey],
+        mongoPass: result[config.mongoUserpassKey],
+      });
+    })
+    .catch(error => console.log(error));
+} else {
+  connectToMongoAndStart({
+    mongoUser: config.mongoUser,
+    mongoPass: config.mongoPass,
   });
+}
 
 process.on('unhandledRejection', (error, p) => {
   console.error('Unhandled Rejection at: Promise', p, 'reason:', error.stack);

--- a/models/UserProfile.ts
+++ b/models/UserProfile.ts
@@ -42,6 +42,15 @@ export const CreateUserModel = () => {
     website: 'String',
     googleScholarId: 'String',
     interests: ['String'],
+
+    sets: [
+      {
+        name: 'String',
+        size: 'String',
+        type: { type: 'String' },
+        setId: 'String',
+      },
+    ],
   });
 
   userModel = mongoose.model('UserModel', UserSchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -293,6 +293,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "1.4.1",
+        "is-buffer": "1.1.6"
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -1179,7 +1188,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "0.10.37"
+        "es5-ext": "0.10.42"
       }
     },
     "dashdash": {
@@ -1315,9 +1324,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "ego-token-middleware": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/ego-token-middleware/-/ego-token-middleware-0.0.5.tgz",
-      "integrity": "sha512-+QZipLs6r1al4tVTz6IzosT6buHT9HOPNp2Rvu+bpRrL+XAFloyMtydeVKygZxu13HECHMsI4eUBpYqkMoCS1Q==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/ego-token-middleware/-/ego-token-middleware-0.0.6.tgz",
+      "integrity": "sha512-S5Pmg90oCqY7KZmRG/tp94FMTvjWmai25YxJUDMZpm3UiG1TF3GZ/f6RXgjrEluJDkw//jMKjJHpygQ96bTuFA==",
       "requires": {
         "axios": "0.18.0",
         "jsonwebtoken": "8.2.1",
@@ -1325,60 +1334,6 @@
         "url-join": "4.0.0"
       },
       "dependencies": {
-        "axios": {
-          "version": "0.18.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-          "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
-          "requires": {
-            "follow-redirects": "1.4.1",
-            "is-buffer": "1.1.6"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
-          "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
-          "requires": {
-            "debug": "3.1.0"
-          }
-        },
-        "jsonwebtoken": {
-          "version": "8.2.1",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
-          "integrity": "sha512-l8rUBr0fqYYwPc8/ZGrue7GiW7vWdZtZqelxo4Sd5lMvuEeCK8/wS54sEo6tJhdZ6hqfutsj6COgC0d1XdbHGw==",
-          "requires": {
-            "jws": "3.1.4",
-            "lodash.includes": "4.3.0",
-            "lodash.isboolean": "3.0.3",
-            "lodash.isinteger": "4.0.4",
-            "lodash.isnumber": "3.0.3",
-            "lodash.isplainobject": "4.0.6",
-            "lodash.isstring": "4.0.1",
-            "lodash.once": "4.1.1",
-            "ms": "2.1.1",
-            "xtend": "4.0.1"
-          }
-        },
-        "memoizee": {
-          "version": "0.4.12",
-          "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.12.tgz",
-          "integrity": "sha512-sprBu6nwxBWBvBOh5v2jcsGqiGLlL2xr2dLub3vR8dnE8YB17omwtm/0NSHl8jjNbcsJd5GMWJAnTSVe/O0Wfg==",
-          "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.37",
-            "es6-weak-map": "2.0.2",
-            "event-emitter": "0.3.5",
-            "is-promise": "2.1.0",
-            "lru-queue": "0.1.0",
-            "next-tick": "1.0.0",
-            "timers-ext": "0.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        },
         "url-join": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
@@ -1419,12 +1374,13 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.37",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.37.tgz",
-      "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
+      "version": "0.10.42",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
+      "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
       "requires": {
         "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "es6-symbol": "3.1.1",
+        "next-tick": "1.0.0"
       }
     },
     "es6-iterator": {
@@ -1433,7 +1389,7 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.42",
         "es6-symbol": "3.1.1"
       }
     },
@@ -1448,7 +1404,7 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37"
+        "es5-ext": "0.10.42"
       }
     },
     "es6-weak-map": {
@@ -1457,7 +1413,7 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.42",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -1535,12 +1491,12 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37"
+        "es5-ext": "0.10.42"
       }
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -1794,6 +1750,14 @@
       "dev": true,
       "requires": {
         "locate-path": "2.0.0"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
+      "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+      "requires": {
+        "debug": "3.1.0"
       }
     },
     "for-in": {
@@ -2880,49 +2844,38 @@
       }
     },
     "graphql-compose": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/graphql-compose/-/graphql-compose-3.1.1.tgz",
-      "integrity": "sha512-+P7cDG+QlImBiesAfd0eWxlmJgh6PS610X58vJBctQ6gS2xKEYgq5zkVtYyffYlhGcL0TJyviBeIu8ThZpXk5A==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/graphql-compose/-/graphql-compose-4.0.1.tgz",
+      "integrity": "sha512-JmjmFR4F9aDZ+j25xL51MyB7IaRmzO9PJDiTnPSTbHZ5yjbtdxEt5GvT0/MvAoJ1yaz/vlL5ytqJDr8zJsnqhw==",
       "requires": {
         "babel-runtime": "6.26.0",
         "object-path": "0.11.4"
       }
     },
     "graphql-compose-connection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/graphql-compose-connection/-/graphql-compose-connection-3.0.0.tgz",
-      "integrity": "sha512-DdggRs11llqETz/cbD46OvXTYTP5o1MdOj3Duiu7a1V1B+qsSQ0wqAujjhnK4kx3QLlIIlK5AhysJSVdh6g+oQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/graphql-compose-connection/-/graphql-compose-connection-3.0.1.tgz",
+      "integrity": "sha512-uKaRG7z+/iPRTeH0+4iSXMPeDyFlVcbu2Iv0Dz2OtSYDAlH9ge1pb03Ne3MA1stDys1OZVBpMVNZKyq237/zjg==",
       "optional": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
     },
     "graphql-compose-mongoose": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/graphql-compose-mongoose/-/graphql-compose-mongoose-3.1.3.tgz",
-      "integrity": "sha512-nyBm1DVf9hluo9KsYty0rHLymbaCy87CODk40fFLZxZL20z5wAJPnu2fmCOT/QOx2iThNZl5j7xqK/i2Vz45FQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-compose-mongoose/-/graphql-compose-mongoose-4.1.0.tgz",
+      "integrity": "sha512-wsDlSHr7RuWuJly4nzv8Y4G9FBF42hvOhoGBOth+aPekISV1BEIvDLAAG1ziEEWhCfYqwse/D28V4c3hPjXUJQ==",
       "requires": {
         "babel-runtime": "6.26.0",
-        "graphql-compose-connection": "3.0.0",
+        "graphql-compose-connection": "3.0.1",
         "graphql-compose-pagination": "3.0.1",
         "object-path": "0.11.4"
-      },
-      "dependencies": {
-        "graphql-compose-pagination": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/graphql-compose-pagination/-/graphql-compose-pagination-3.0.1.tgz",
-          "integrity": "sha512-vtRfsiiJkH8eQa9ytFI4qE2DoxOi6jQZURy1tSRIV9WZe3TEr1JXtxYLIKVia0JT+LMPwx5aX+V2LG1bAgZEXg==",
-          "optional": true,
-          "requires": {
-            "babel-runtime": "6.26.0"
-          }
-        }
       }
     },
     "graphql-compose-pagination": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/graphql-compose-pagination/-/graphql-compose-pagination-1.1.5.tgz",
-      "integrity": "sha512-XqYVBmn6KJ8zt52iIMFCEKoZWHIipeO3Vqi1z2qzJiM/4vGYb7oLc8Z3Yg7PG7o9wRfQnzjauecuaA0e/mMWOA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/graphql-compose-pagination/-/graphql-compose-pagination-3.0.1.tgz",
+      "integrity": "sha512-vtRfsiiJkH8eQa9ytFI4qE2DoxOi6jQZURy1tSRIV9WZe3TEr1JXtxYLIKVia0JT+LMPwx5aX+V2LG1bAgZEXg==",
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -3868,6 +3821,30 @@
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
+    "jsonwebtoken": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
+      "integrity": "sha512-l8rUBr0fqYYwPc8/ZGrue7GiW7vWdZtZqelxo4Sd5lMvuEeCK8/wS54sEo6tJhdZ6hqfutsj6COgC0d1XdbHGw==",
+      "requires": {
+        "jws": "3.1.4",
+        "lodash.includes": "4.3.0",
+        "lodash.isboolean": "3.0.3",
+        "lodash.isinteger": "4.0.4",
+        "lodash.isnumber": "3.0.3",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.isstring": "4.0.1",
+        "lodash.once": "4.1.1",
+        "ms": "2.1.1",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -4195,7 +4172,7 @@
       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
       "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
       "requires": {
-        "es5-ext": "0.10.37"
+        "es5-ext": "0.10.42"
       }
     },
     "make-dir": {
@@ -4239,6 +4216,21 @@
       "dev": true,
       "requires": {
         "mimic-fn": "1.1.0"
+      }
+    },
+    "memoizee": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.12.tgz",
+      "integrity": "sha512-sprBu6nwxBWBvBOh5v2jcsGqiGLlL2xr2dLub3vR8dnE8YB17omwtm/0NSHl8jjNbcsJd5GMWJAnTSVe/O0Wfg==",
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.42",
+        "es6-weak-map": "2.0.2",
+        "event-emitter": "0.3.5",
+        "is-promise": "2.1.0",
+        "lru-queue": "0.1.0",
+        "next-tick": "1.0.0",
+        "timers-ext": "0.1.5"
       }
     },
     "merge": {
@@ -5882,11 +5874,11 @@
       "dev": true
     },
     "timers-ext": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.2.tgz",
-      "integrity": "sha1-YcxHp2wavTGV8UUn+XjViulMUgQ=",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.5.tgz",
+      "integrity": "sha512-tsEStd7kmACHENhsUPaxb8Jf8/+GZZxyNFQbZD07HQOyooOa6At1rQqjffgvg7n+dxscQa9cjjMdWhJtsP2sxg==",
       "requires": {
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.42",
         "next-tick": "1.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -23,16 +23,15 @@
   "dependencies": {
     "@types/node": "^8.0.51",
     "babel-polyfill": "^6.26.0",
-    "bluebird": "^3.5.1",
     "cors": "^2.8.4",
     "dotenv": "^4.0.0",
-    "ego-token-middleware": "0.0.5",
+    "ego-token-middleware": "0.0.6",
     "express": "^4.16.2",
     "express-graphql": "^0.6.11",
     "graphql": "^0.11.7",
-    "graphql-compose": "^3.0.6",
-    "graphql-compose-mongoose": "^3.1.1",
-    "graphql-compose-pagination": "^1.1.2",
+    "graphql-compose": "^4.0.1",
+    "graphql-compose-mongoose": "^4.1.0",
+    "graphql-compose-pagination": "^3.0.1",
     "mongoose": "^4.13.1",
     "ms": "^2.0.0",
     "node-vault": "^0.8.0",
@@ -58,22 +57,9 @@
       "<rootDir>/**/__tests__/**/*.(js|jsx|ts|tsx)",
       "<rootDir>/**/?(*.)(spec|test).(js|jsx|ts|tsx)"
     ],
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/fixtures/",
-      "setupJest.js"
-    ],
-    "moduleDirectories": [
-      "node_modules",
-      "./"
-    ],
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "jsx",
-      "json"
-    ]
+    "testPathIgnorePatterns": ["/node_modules/", "/fixtures/", "setupJest.js"],
+    "moduleDirectories": ["node_modules", "./"],
+    "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json"]
   },
   "prettier": {
     "trailingComma": "all",


### PR DESCRIPTION
overview:
- added the `sets` field to the user model
- the previous `restrict` method that wraps the protected resolvers was squashing errors into an ambiguous `aggregate error`. now errors are happily returned to the client
- a check to only try to connect to vault if we've set persona's keys to do so. if not configured it'll default to mongo connection w/ username + password
- upgraded ego token middleware (included a no-body bug fix)
- upgraded gql-compose related packages in the process of debugging the ambiguous error issues, it works so I kept the upgrades in