### PR TITLE
🐛 migrate-mongo fails if dist folder is not present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules/
 .env
 logs
-migrations/dist
+migrations/dist/*.js


### PR DESCRIPTION
ensures that migrate build folder (`migrations/dist`) will be present so that `npm run migrate -- up` | `npm run migrate -- down` don't fail. 