### PR TITLE
🐛 fixes vault lib imports and adds better .env.schema examples

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -6,14 +6,14 @@ MONGO_HOST=
 MONGO_DB=
 
 # fallback if not using vault
-MONGO_USER=
-MONGO_PASS=
+MONGO_USER=username
+MONGO_PASS=pass
 
 # vault authentication configs, VAULT_TOKEN can be empty if using AWS_IAM
 VAULT_AUTHENTICATION=AWS_IAM|TOKEN
 AWS_IAM_ROLE=
-VAULT_ENDPOINT_PROTOCOL=
-VAULT_HOST=
+VAULT_ENDPOINT_PROTOCOL=http|https
+VAULT_HOST=vault.domain.com
 VAULT_PORT=
 VAULT_API_VERSION=v1  // this is the default fallback for node-vault
 VAULT_TOKEN=

--- a/services/vault.ts
+++ b/services/vault.ts
@@ -1,5 +1,5 @@
-import vaultAuthAws from 'vault-auth-aws';
-import vault from 'node-vault';
+import * as vaultAuthAws from 'vault-auth-aws';
+import * as vault from 'node-vault';
 import {
   awsIamRole,
   vaultAuthentication,


### PR DESCRIPTION
Turned out, typescript has this weird thing where dependency imports have to be done with a wildcat. Not sure why it was working for me locally still. I've already fixed the environment in the vm.