### PR TITLE
✨ user / users resolvers will only return public profiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "NODE_PATH=./ ts-node examples/app.ts",
     "test": "NODE_PATH=./ jest .test --notify",
     "build": "rm -rf dist && mkdir dist && NODE_PATH=./ tsc",
-    "prepare": "rm -rf dist && mkdir dist && NODE_PATH=./ tsc"
+    "prepare": "rm -rf dist && mkdir dist && NODE_PATH=./ tsc",
+    "watch": "rm -rf dist && mkdir dist && NODE_PATH=./ tsc -w"
   },
   "repository": {
     "type": "git",
@@ -67,22 +68,9 @@
       "<rootDir>/**/__tests__/**/*.(js|jsx|ts|tsx)",
       "<rootDir>/**/?(*.)(spec|test).(js|jsx|ts|tsx)"
     ],
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/fixtures/",
-      "setupJest.js"
-    ],
-    "moduleDirectories": [
-      "node_modules",
-      "./"
-    ],
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "jsx",
-      "json"
-    ]
+    "testPathIgnorePatterns": ["/node_modules/", "/fixtures/", "setupJest.js"],
+    "moduleDirectories": ["node_modules", "./"],
+    "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json"]
   },
   "prettier": {
     "trailingComma": "all",

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -41,8 +41,8 @@ const createSchema = ({ models, tags }) => {
 
   GQC.rootQuery().addFields({
     self: restrict(UserTC.getResolver('self'), validToken),
-    user: restrict(UserTC.getResolver('findById'), isAdmin),
-    users: restrict(UserTC.getResolver('pagination'), isAdmin),
+    user: restrict(UserTC.getResolver('protectedFindById')),
+    users: restrict(UserTC.getResolver('protectedPagination')),
     tags: TagsTC.getResolver('listAll'),
   });
 

--- a/src/graphql/schema/User/index.ts
+++ b/src/graphql/schema/User/index.ts
@@ -1,16 +1,34 @@
 import { composeWithMongoose } from 'graphql-compose-mongoose';
+import { set } from 'lodash';
 
 import { self as selfResolver } from './resolvers';
 
-export default ({ models }) => {
-  const UserTC = composeWithMongoose(models.User, {});
+export default ({ models: { User } }) => {
+  const UserTC = composeWithMongoose(User, {});
 
   UserTC.addResolver({
     kind: 'query',
     name: 'self',
     type: UserTC,
-    resolve: selfResolver(models.User),
+    resolve: selfResolver(User),
   });
+
+  UserTC.setResolver(
+    'protectedFindById',
+    UserTC.getResolver('findById').wrapResolve(next => async rp => {
+      const result = await next(rp);
+      return result && (await User.findById(rp.args._id)).isPublic
+        ? result
+        : null;
+    }),
+  );
+
+  UserTC.setResolver(
+    'protectedPagination',
+    UserTC.getResolver('pagination').wrapResolve(next => rp =>
+      next(set(rp, 'args.filter', { ...rp.args.filter, isPublic: true })),
+    ),
+  );
 
   return UserTC;
 };

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -6,6 +6,10 @@ export default {
       required: true,
       unique: true,
     },
+    isPublic: {
+      type: 'Boolean',
+      default: false,
+    },
   },
   collection: 'usermodels',
 };


### PR DESCRIPTION
This changes a few things:
- makes `user` / `users` resolvers available to everyone (not just admins)
- adds an `isPublic` persona-core field to the user model, defaulting to `false`
- `user` resolver returns null if profile is not public
- `users` resolver only returns hits for profiles that are public (so as to not break pagination)